### PR TITLE
Little Bug-fix for special chars in URI, unfortunately quoted a second time...

### DIFF
--- a/templates/js/tree.js
+++ b/templates/js/tree.js
@@ -1,6 +1,6 @@
 function linkClickedFunction(event) {
     event.preventDefault();
-    target = this.href;
+    target = unescape(this.href);
     $.History.go(target);
 }
 


### PR DESCRIPTION
.... e.g whitespace (%20) becomes (%2520) and therefore an HTTP 404 occurs.
