### PR TITLE
Use of jQuery attr method to retrieve the href attribute

### DIFF
--- a/templates/js/tree.js
+++ b/templates/js/tree.js
@@ -1,6 +1,6 @@
 function linkClickedFunction(event) {
     event.preventDefault();
-    target = this.href;
+    target = $(this).attr('href');
     $.History.go(target);
 }
 


### PR DESCRIPTION
In order to reduce inconsistencies across browsers. That way the #review is loaded properly even when the URI contains spaces.
