### PR TITLE
fix issue #20 for dealing with Chinese correctly

### DIFF
--- a/src/View/ViewReview.php
+++ b/src/View/ViewReview.php
@@ -269,7 +269,7 @@ class CbViewReview extends CbViewAbstract
         }
 
         $sourceDom = new DOMDocument();
-        $sourceDom->loadHTML('<?xml encoding="UTF-8">' . $code);
+        $sourceDom->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>' . $code);
 
         //fetch <code>-><span>->children from php generated html
         $sourceElements = $sourceDom->getElementsByTagname('code')->item(0)


### PR DESCRIPTION
If we change the code of ViewReview.php at line 272 from

> $sourceDom->loadHTML('<?xml encoding="UTF-8">' . $code);

to

> $sourceDom->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>' . $code);

It will be correct.

Otherwise all Chinese characters are appeared as messy code in results.
