### PR TITLE
Fix symlink when installed via composer

### DIFF
--- a/bin/phpcb
+++ b/bin/phpcb
@@ -47,7 +47,7 @@
  * @since     File available since  0.1.0
  */
 
-require_once dirname(__FILE__) . '/../vendor/autoload.php';
+(@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';
 
 $app = new PHPCodeBrowser\Application();
 $app->run();


### PR DESCRIPTION
version `1.1@beta` doesn't work when using the symlink installed by composer.
this fixes that.

unsure which branch this was meant to target.
master and 1.1 seem the same.

thanks
