### PR TITLE
Handle slashes on windows

### DIFF
--- a/src/PHPCodeBrowser/File.php
+++ b/src/PHPCodeBrowser/File.php
@@ -89,6 +89,11 @@ class File
      */
     public function __construct($name, array $issues = array())
     {
+        if (DIRECTORY_SEPARATOR !== '/')
+        {
+            $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
+        }
+
         $this->name = $name;
         $this->issues = $issues;
     }


### PR DESCRIPTION
Handle slashes on windows, otherwise one may receive duplicated entries in result page: 
- `D:\app/controllers/BaseController.php`, 
- `D:\app\controllers\BaseController.php` 

and so on, particularly with PHPUnit coverage report.