### PR TITLE
issues #41 : ErrorCoverage plugin does not find files in clover.xml when files are in package

### DIFF
--- a/src/PHPCodeBrowser/Plugins/ErrorCoverage.php
+++ b/src/PHPCodeBrowser/Plugins/ErrorCoverage.php
@@ -175,7 +175,7 @@ class ErrorCoverage extends PluginsAbstract
     {
         $fileNames  = array();
         $issueNodes = $this->issueXml->query(
-            '/*/'.$this->pluginName.'/*/file[@name]'
+            '/*/'.$this->pluginName.'/*//file[@name]'
         );
 
         foreach ($issueNodes as $node) {
@@ -194,7 +194,7 @@ class ErrorCoverage extends PluginsAbstract
     protected function getIssueNodes($filename)
     {
         return $this->issueXml->query(
-            '/*/'.$this->pluginName.'/*/file[@name="'.$filename.'"]'
+            '/*/'.$this->pluginName.'/*//file[@name="'.$filename.'"]'
         );
     }
 }


### PR DESCRIPTION
expands the xPath query to find all nodes under "coverage" node
