### PR TITLE
Fix displayed version in CLI

### DIFF
--- a/bin/phpcb
+++ b/bin/phpcb
@@ -53,5 +53,5 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
     include_once __DIR__ . '/../vendor/autoload.php';
 }
 
-$app = new PHPCodeBrowser\Application('PHP_CodeBrowser', '1.1.1');
+$app = new PHPCodeBrowser\Application('PHP_CodeBrowser', '1.1.2');
 $app->run();


### PR DESCRIPTION
I installed latest version `1.1.2. BUt the version displayed by the CLI was `1.1.1`
```
$ phpcb -V
PHP_CodeBrowser 1.1.1
```
