### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 language: php
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 dist: trusty
 language: php
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
     - hhvm
 before_script:
     - composer install

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 # PHP_CodeBrowser #
 
 [![Latest Stable Version](https://poser.pugx.org/mayflower/php-codebrowser/v/stable.png)](https://packagist.org/packages/mayflower/php-codebrowser)
-[![Build Status](https://travis-ci.org/Mayflower/PHP_CodeBrowser.png?branch=master)](https://travis-ci.org/Mayflower/PHP_CodeBrowser)
+[![Build Status](https://travis-ci.org/mayflower/PHP_CodeBrowser.png?branch=master)](https://travis-ci.org/mayflower/PHP_CodeBrowser)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Mayflower/PHP_CodeBrowser/badges/quality-score.png?s=2c0379f0efea966daeaef3fc5abf8adb4a910b24)](https://scrutinizer-ci.com/g/Mayflower/PHP_CodeBrowser/)
 [![Code Coverage](https://scrutinizer-ci.com/g/Mayflower/PHP_CodeBrowser/badges/coverage.png?s=543238e3d9fb4584d8cb31e3af48e67ed846f9e5)](https://scrutinizer-ci.com/g/Mayflower/PHP_CodeBrowser/)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/79205008-1c3d-4142-ab81-a9465008d440/mini.png)](https://insight.sensiolabs.com/projects/79205008-1c3d-4142-ab81-a9465008d440)

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "phpunit/php-file-iterator": "~1.3",
+        "phpunit/php-file-iterator": "~1.4",
         "monolog/monolog": "~1.7",
         "symfony/console": "~2.1|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "5.7.*",
         "phpmd/phpmd": "1.5.*",
         "squizlabs/php_codesniffer": "1.*",
         "phploc/phploc": "*",

--- a/src/PHPCodeBrowser/Tests/View/ViewReviewTest.php
+++ b/src/PHPCodeBrowser/Tests/View/ViewReviewTest.php
@@ -90,7 +90,7 @@ class ViewReviewTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->ioMock = $this->getMock('PHPCodeBrowser\Helper\IOHelper');
+        $this->ioMock = $this->createMock('PHPCodeBrowser\Helper\IOHelper');
 
         $this->viewReview = new ViewReview(
             PHPCB_ROOT_DIR . '/../templates/',


### PR DESCRIPTION
phpunit 5.7 is required for testing on php 7.2, but phpunit 5.7 does not support php < 5.6 therefore dropped testing for php 5.3, 5.4 and 5.5