### PR TITLE
WIP: php-file-iterator-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 language: php
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
     - 7.1
     - 7.2
-    - hhvm
 before_script:
     - composer install
 script:

--- a/box.json
+++ b/box.json
@@ -16,12 +16,16 @@
             "name": "*.php",
             "path": [
                 "composer",
+                "herrera-io/json",
+                "herrera-io/phar-update",
                 "monolog/monolog",
+                "myclabs/deep-copy",
+                "phpseclib/phpseclib",
                 "phpunit/php-file-iterator",
+                "psr/log",
                 "symfony/console",
                 "symfony/polyfill-mbstring",
-                "myclabs/deep-copy",
-                "psr/log"
+                "symfony/polyfill-ctype"
             ],
             "notPath": [
                 "Tests",

--- a/composer.json
+++ b/composer.json
@@ -11,19 +11,40 @@
         }
     ],
     "require": {
-        "phpunit/php-file-iterator": "~1.4",
+        "php": "^7.1",
+        "phpunit/php-file-iterator": "~2.0",
         "monolog/monolog": "~1.7",
         "symfony/console": "~2.1|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*",
-        "phpmd/phpmd": "1.5.*",
-        "squizlabs/php_codesniffer": "1.*",
+        "phpunit/phpunit": "~7.3",
+        "phpmd/phpmd": "1.5.*|~2.6",
+        "squizlabs/php_codesniffer": "1.*|~3.3",
         "phploc/phploc": "*",
-        "sebastian/phpcpd": "*"
+        "sebastian/phpcpd": "*",
+        "kherge/box": "~2.7"
     },
     "autoload": {
         "psr-0": {"PHPCodeBrowser\\": "src/"}
     },
-    "bin": [ "bin/phpcb" ]
+    "bin": [ "bin/phpcb" ],
+    "scripts": {
+        "demo": [
+            "@clean",
+            "php -c php.ini vendor/bin/phpunit -c phpunit.xml.dist",
+            "phpcpd -q --log-pmd=build/logs/pmd-cpd.xml src || true",
+            "phpmd src xml cleancode,codesize,controversial,design,naming,unusedcode --reportfile build/logs/pmd.xml || true",
+            "@browser"
+        ],
+        "nope": [
+            "@clean",
+            "pdepend --quiet --dependency-xml=build/logs/pdepend.xml src || true",
+            "phpcs -q --standard=PSR2 --report-xml=build/logs/checkstyle.xml src || true",
+            "phploc -q --log-xml=build/logs/phploc.xml src || true",
+            "@browser"
+        ],
+        "clean": "rm -rf build/logs/* build/code-browser",
+        "browser": "bin/phpcb -l build/logs -o build/code-browser -s src",
+        "phar": "php -d phar.readonly=0 vendor/bin/box build"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
             "php -c php.ini vendor/bin/phpunit -c phpunit.xml.dist",
             "phpcpd -q --log-pmd=build/logs/pmd-cpd.xml src || true",
             "phpmd src xml cleancode,codesize,controversial,design,naming,unusedcode --reportfile build/logs/pmd.xml || true",
+            "phpcs -q --standard=PSR2 --report-checkstyle=build/logs/checkstyle.xml src || true",
             "@browser"
         ],
         "nope": [
             "@clean",
             "pdepend --quiet --dependency-xml=build/logs/pdepend.xml src || true",
-            "phpcs -q --standard=PSR2 --report-xml=build/logs/checkstyle.xml src || true",
             "phploc -q --log-xml=build/logs/phploc.xml src || true",
             "@browser"
         ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./vendor/autoload.php"
 >
     <testsuites>
@@ -26,28 +25,14 @@
         </whitelist>
     </filter>
 
-  <!--<filter>-->
-    <!--<whitelist>-->
-      <!--<directory suffix='.php'>src</directory>-->
-    <!--</whitelist>-->
-  <!--</filter>-->
+    <logging>
+        <!--<log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70"/>-->
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="junit" target="build/logs/junit.xml"/>
+    </logging>
 
-  <logging>
-    <log type="coverage-html" target="build/coverage" title="PHP_CodeBrowser"
-         charset="UTF-8" yui="true" highlight="true"
-         lowUpperBound="35" highLowerBound="70"/>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-    <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
-  </logging>
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
 
-  <php>
-    <!--TODO: Remove this when E_STRICT stops crashing the tests -->
-    <!--<ini name="error_reporting" value="E_ALL"/>-->
-  </php>
-
-  <filter>
-    <whitelist>
-      <directory>src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/src/PHPCodeBrowser/CLIController.php
+++ b/src/PHPCodeBrowser/CLIController.php
@@ -49,7 +49,7 @@
 
 namespace PHPCodeBrowser;
 
-use SebastianBergmann\FileIterator\Factory;
+use SebastianBergmann\FileIterator\Factory as FileIteratorFactory;
 use Monolog\Logger;
 use PHPCodeBrowser\Helper\IOHelper;
 use PHPCodeBrowser\View\ViewReview;
@@ -273,7 +273,7 @@ class CLIController
         if (isset($this->projectSource)) {
             foreach ($this->projectSource as $source) {
                 if (is_dir($source)) {
-                    $factory = new Factory;
+                    $factory = new FileIteratorFactory;
 
                     $suffixes = array_merge(
                         $this->phpSuffixes,

--- a/src/PHPCodeBrowser/CLIController.php
+++ b/src/PHPCodeBrowser/CLIController.php
@@ -49,7 +49,7 @@
 
 namespace PHPCodeBrowser;
 
-use File_Iterator_Factory;
+use SebastianBergmann\FileIterator\Factory;
 use Monolog\Logger;
 use PHPCodeBrowser\Helper\IOHelper;
 use PHPCodeBrowser\View\ViewReview;
@@ -273,7 +273,7 @@ class CLIController
         if (isset($this->projectSource)) {
             foreach ($this->projectSource as $source) {
                 if (is_dir($source)) {
-                    $factory = new File_Iterator_Factory;
+                    $factory = new Factory;
 
                     $suffixes = array_merge(
                         $this->phpSuffixes,

--- a/src/PHPCodeBrowser/IssueXml.php
+++ b/src/PHPCodeBrowser/IssueXml.php
@@ -49,7 +49,7 @@
 
 namespace PHPCodeBrowser;
 
-use SebastianBergmann\FileIterator\Factory;
+use SebastianBergmann\FileIterator\Factory as FileIteratorFactory;
 use \DOMDocument;
 use \DOMNode;
 use \DOMNodeList;
@@ -121,7 +121,7 @@ class IssueXml extends DOMDocument
      */
     public function addDirectory($directory)
     {
-        $factory  = new Factory;
+        $factory  = new FileIteratorFactory;
         $iterator = $factory->getFileIterator($directory, 'xml');
 
         foreach ($iterator as $current) {

--- a/src/PHPCodeBrowser/IssueXml.php
+++ b/src/PHPCodeBrowser/IssueXml.php
@@ -49,6 +49,7 @@
 
 namespace PHPCodeBrowser;
 
+use SebastianBergmann\FileIterator\Factory;
 use \DOMDocument;
 use \DOMNode;
 use \DOMNodeList;
@@ -120,7 +121,7 @@ class IssueXml extends DOMDocument
      */
     public function addDirectory($directory)
     {
-        $factory  = new \File_Iterator_Factory();
+        $factory  = new Factory;
         $iterator = $factory->getFileIterator($directory, 'xml');
 
         foreach ($iterator as $current) {

--- a/src/PHPCodeBrowser/Tests/AbstractTestCase.php
+++ b/src/PHPCodeBrowser/Tests/AbstractTestCase.php
@@ -61,7 +61,7 @@ namespace PHPCodeBrowser\Tests;
  * @link       http://www.phpunit.de/
  * @since      Class available since  0.1.0
  */
-class AbstractTestCase extends \PHPUnit_Framework_TestCase
+class AbstractTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Merged cruisecontrol XML error file

--- a/src/PHPCodeBrowser/Tests/ApplicationTest.php
+++ b/src/PHPCodeBrowser/Tests/ApplicationTest.php
@@ -8,7 +8,7 @@ use PHPCodeBrowser\Application;
  * Class ApplicationTest
  * @package PHPCodeBrowser\Tests
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Application

--- a/src/PHPCodeBrowser/Tests/FileTest.php
+++ b/src/PHPCodeBrowser/Tests/FileTest.php
@@ -85,6 +85,7 @@ class FileTest extends AbstractTestCase
      */
     public function __construct()
     {
+        parent::__construct();
         $this->issues = array(
             new Issue('/some/file/name.php', 39, 39, 'Checkstyle', 'm3', 'error'),
             new Issue('/some/file/name.php', 50, 52, 'Checkstyle', 'm4', 'warning'),
@@ -138,13 +139,10 @@ class FileTest extends AbstractTestCase
      */
     public function testAddingIssueToWrongFile()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $issue = new Issue('/the/wrong/file/name.php', 39, 39, 'Checkstyle', 'm3', 'error');
-        try {
-            $this->file->addIssue($issue);
-            $this->fail();
-        } catch (\InvalidArgumentException $e) {
-            // Expected
-        }
+        $this->file->addIssue($issue);
     }
 
 
@@ -244,12 +242,9 @@ class FileTest extends AbstractTestCase
      */
     public function testMergeWithDifferentFile()
     {
-        try {
-            $this->file->mergeWith(new File('/the/wrong/file/name.php'));
-            $this->fail();
-        } catch (\InvalidArgumentException $e) {
-            // Expected
-        }
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->file->mergeWith(new File('/the/wrong/file/name.php'));
     }
 
     /**

--- a/src/PHPCodeBrowser/Tests/Helper/IOHelperTest.php
+++ b/src/PHPCodeBrowser/Tests/Helper/IOHelperTest.php
@@ -208,16 +208,13 @@ class IOHelperTest extends AbstractTestCase
      */
     public function testLoadFileWithNonexistentFile()
     {
+        $this->expectException(\Exception::class);
+
         $sourceFile = PHPCB_TEST_OUTPUT . '/doesNotExist';
         if (file_exists($sourceFile)) {
             unlink(PHPCB_TEST_OUTPUT . '/doesNotExist');
         }
-        try {
-            $this->ioHelper->loadFile($sourceFile);
-            $this->fail();
-        } catch (\Exception $e) {
-            // expected
-        }
+        $this->ioHelper->loadFile($sourceFile);
     }
 
 
@@ -228,6 +225,8 @@ class IOHelperTest extends AbstractTestCase
      */
     public function testCopyFileNonExisting()
     {
+        $this->expectException(\Exception::class);
+
         $file = PHPCB_TEST_OUTPUT . '/tmpfile';
         $dstDir = PHPCB_TEST_OUTPUT . '/tmpdir';
 
@@ -235,12 +234,7 @@ class IOHelperTest extends AbstractTestCase
             unlink($file);
         }
 
-        try {
-            $this->ioHelper->copyFile($file, $dstDir);
-        } catch (\Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception was not thrown.');
+        $this->ioHelper->copyFile($file, $dstDir);
     }
 
     /**

--- a/src/PHPCodeBrowser/Tests/SourceHandlerTest.php
+++ b/src/PHPCodeBrowser/Tests/SourceHandlerTest.php
@@ -98,6 +98,7 @@ class SourceHandlerTest extends AbstractTestCase
      */
     public function __construct()
     {
+        parent::__construct();
         $xmlStrings = array(
             <<<HERE
 <?xml version="1.0" encoding="UTF-8"?>
@@ -235,15 +236,11 @@ HERE
      */
     public function testAddSourceFilesWithNonExisting()
     {
-        try {
-            $this->sourceHandler->addSourceFiles(
-                array(new SplFileInfo('/i/do/not/exist'))
-            );
-        } catch (Exception $e) {
-            //expected
-            return;
-        }
-        $this->fail('Expected Exception was not thrown');
+        $this->expectException(\Exception::class);
+
+        $this->sourceHandler->addSourceFiles(
+            array(new SplFileInfo('/i/do/not/exist'))
+        );
     }
 
     /**


### PR DESCRIPTION
- drop support for php < 7.1 because of php-file-iterator
- update php-file-iterator to 2.0.1
- update phpunit to 7.3.1
- add kherge/box 2.7.5 for packaging phar
- add composer scripts to ease development

To satisfy #55 
Any opinions on dropping support for lower php versions?