### PR TITLE
Fix phar build #69

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,0 +1,33 @@
+{
+    "alias": "phpcb.phar",
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\Json",
+        "KevinGH\\Box\\Compactor\\Php"
+    ],
+    "directories": ["src", "templates"],
+    "files": [
+        "LICENSE",
+        "vendor/autoload.php"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "path": [
+                "monolog/monolog",
+                "phpunit/php-file-iterator",
+                "psr/log",
+                "symfony/console",
+                "symfony/service-contracts"
+            ],
+            "notPath": [
+                "Tests",
+                "test",
+                "tests"
+            ],
+            "in": "vendor"
+        }
+    ],
+    "git-commit": "git-commit",
+    "git-version": "git-version",
+    "output": "phpcb-@git-version@.phar"
+}

--- a/box.json
+++ b/box.json
@@ -29,5 +29,5 @@
     ],
     "git-commit": "git-commit",
     "git-version": "git-version",
-    "output": "phpcb-@git-version@.phar"
+    "output": "phpcb-2.3.1.phar"
 }

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,6 @@
         ],
         "clean": "rm -rf build/logs/* build/code-browser",
         "browser": "bin/phpcb -l build/logs -o build/code-browser -s src",
-        "phar": "php -d phar.readonly=0 vendor/bin/box build"
+        "phar": "php vendor/bin/box compile"
     }
 }


### PR DESCRIPTION
templates folder was missing in the resulting pharchive.
cleaned the finder paths to the necessary minimum.