### PR TITLE
prevent errors on php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-dom": "*",
         "monolog/monolog": "~1.7||~2.0",
         "phpunit/php-file-iterator": "~2.0||^3.0",
-        "symfony/console": "~3.4||~4.0||~5.0"
+        "symfony/console": "~3.4||~4.0||~5.0||~6.0"
     },
     "require-dev": {
         "humbug/box": "^3.13",
@@ -63,5 +63,10 @@
         "clean": "rm -rf build/logs/* build/code-browser",
         "browser": "bin/phpcb -l build/logs -o build/code-browser -s src",
         "phar": "php vendor/bin/box compile"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/PHPCodeBrowser/IssueXML.php
+++ b/src/PHPCodeBrowser/IssueXML.php
@@ -94,22 +94,6 @@ class IssueXML extends DOMDocument
     protected $xpath;
 
     /**
-     * Do not preserve white spaces.
-     *
-     * @see DOMDocument
-     *
-     * @var bool
-     */
-    public $preserveWhiteSpace = false;
-
-    /**
-     * Provide nice output.
-     *
-     * @var bool
-     */
-    public $formatOutput = true;
-
-    /**
      * Default constructor
      *
      * @param string $version  The version definition for DomDocument
@@ -121,6 +105,8 @@ class IssueXML extends DOMDocument
         $this->appendChild(
             $this->createElement('codebrowser')
         );
+        $this->preserveWhiteSpace = false;
+        $this->formatOutput = true;
     }
 
     /**


### PR DESCRIPTION
This should fix issue #79 
I found maybe a better way, that should keep compatibility even with PHP 7.3