### PR TITLE
IssueXML.php: skip DOCTYPE (fixes cobertura)

### DIFF
--- a/phpstan_baseline.neon
+++ b/phpstan_baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/PHPCodeBrowser/IssueXML.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 1
-			path: src/PHPCodeBrowser/IssueXML.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
 			count: 1
 			path: src/PHPCodeBrowser/Plugins/ErrorCRAP.php

--- a/src/PHPCodeBrowser/IssueXML.php
+++ b/src/PHPCodeBrowser/IssueXML.php
@@ -56,6 +56,7 @@
 namespace PHPCodeBrowser;
 
 use DOMDocument;
+use DOMDocumentType;
 use DOMNode;
 use DOMNodeList;
 use DOMXPath;
@@ -155,6 +156,10 @@ class IssueXML extends DOMDocument
     public function addXMLFile(DOMDocument $domDocument): void
     {
         foreach ($domDocument->childNodes as $node) {
+            if ($node instanceof DOMDocumentType) {
+                continue;
+            }
+
             $this->documentElement->appendChild($this->importNode($node, true));
         }
     }


### PR DESCRIPTION
After adding Cobertura XML report to PHPUnit my phpcb crashed with:
> `PHP Fatal error:  Uncaught TypeError: DOMNode::appendChild(): Argument #1 ($node) must be of type DOMNode, bool given in /var/lib/jenkins/.composer/vendor/mayflower/php-codebrowser/src/PHPCodeBrowser/IssueXML.php:158`

This patch skips '<!DOCTYPE coverage SYSTEM ...' (cobertura), which is a DOMNode that can't be imported, and uses the following element instead.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage line-rate="0.71621621621622" branch-rate="0" lines-covered="371" lines-valid="518" branches-covered="0" branches-valid="0" complexity="264" version="0.4" timestamp="1709828073">
```

Might want to also check for false but i think this patch is already deterministic and nice.